### PR TITLE
Context に応じた Injector を利用可能に

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
+/tests/tmp/
 /composer.lock
 /.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
             "email": "akihito.koriyama@gmail.com"
         }
     ],
-    "require": {
+  "require": {
         "php": ">=8.0",
-        "ray/di": "^2.14"
+        "ray/di": "^2.14",
+        "ray/compiler": "^1.8"
     },
     "require-dev": {
         "laravel/framework": "^9.8",

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "php": ">=8.0",
         "ray/di": "^2.14",
         "ray/compiler": "1.x-dev",
-        "doctrine/cache": "^1.10 || ^2.2",
-        "symfony/cache": "^5.4 || ^6.0"
+        "doctrine/cache": "^1.10"
     },
     "require-dev": {
         "laravel/framework": "^9.8",

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,11 @@
             "email": "akihito.koriyama@gmail.com"
         }
     ],
-  "require": {
+    "require": {
         "php": ">=8.0",
         "ray/di": "^2.14",
-        "ray/compiler": "^1.8"
+        "ray/compiler": "^1.8",
+        "doctrine/cache": "^1.10 || ^2.2"
     },
     "require-dev": {
         "laravel/framework": "^9.8",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "php": ">=8.0",
         "ray/di": "^2.14",
         "ray/compiler": "^1.8",
-        "doctrine/cache": "^1.10 || ^2.2"
+        "doctrine/cache": "^1.10 || ^2.2",
+        "symfony/cache": "^5.4 || ^6.0"
     },
     "require-dev": {
         "laravel/framework": "^9.8",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": ">=8.0",
         "ray/di": "^2.14",
         "ray/compiler": "1.x-dev",
-        "doctrine/cache": "^1.10"
+        "doctrine/cache": "^1.10 || ^2.2"
     },
     "require-dev": {
         "laravel/framework": "^9.8",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=8.0",
         "ray/di": "^2.14",
-        "ray/compiler": "^1.8",
+        "ray/compiler": "1.x-dev",
         "doctrine/cache": "^1.10 || ^2.2",
         "symfony/cache": "^5.4 || ^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,8 @@
     "require-dev": {
         "laravel/framework": "^9.8",
         "phpunit/phpunit": "^9.5"
+    },
+    "suggest": {
+      "ext-apcu": "Needed to use ApcuCacheProvider"
     }
 }

--- a/src/ApcuCacheProvider.php
+++ b/src/ApcuCacheProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel;
+
+use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+
+class ApcuCacheProvider
+{
+    public static function create(string $namespace): CacheProvider
+    {
+        $cache = DoctrineProvider::wrap(new ApcuAdapter($namespace));
+        assert($cache instanceof CacheProvider);
+
+        return $cache;
+    }
+}

--- a/src/ApcuCacheProvider.php
+++ b/src/ApcuCacheProvider.php
@@ -4,17 +4,13 @@ declare(strict_types=1);
 
 namespace Ray\RayDiForLaravel;
 
+use Doctrine\Common\Cache\ApcuCache;
 use Doctrine\Common\Cache\CacheProvider;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
-use Symfony\Component\Cache\Adapter\ApcuAdapter;
 
 class ApcuCacheProvider
 {
-    public static function create(string $namespace): CacheProvider
+    public static function create(): CacheProvider
     {
-        $cache = DoctrineProvider::wrap(new ApcuAdapter($namespace));
-        assert($cache instanceof CacheProvider);
-
-        return $cache;
+        return new ApcuCache();
     }
 }

--- a/src/ApcuCacheProvider.php
+++ b/src/ApcuCacheProvider.php
@@ -4,13 +4,94 @@ declare(strict_types=1);
 
 namespace Ray\RayDiForLaravel;
 
-use Doctrine\Common\Cache\ApcuCache;
+use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
 
-class ApcuCacheProvider
+class ApcuCacheProvider extends CacheProvider
 {
-    public static function create(): CacheProvider
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch($id)
     {
-        return new ApcuCache();
+        return apcu_fetch($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doContains($id)
+    {
+        return apcu_exists($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave($id, $data, $lifeTime = 0)
+    {
+        return apcu_store($id, $data, $lifeTime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete($id)
+    {
+        // apcu_delete returns false if the id does not exist
+        return apcu_delete($id) || ! apcu_exists($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDeleteMultiple(array $keys)
+    {
+        $result = apcu_delete($keys);
+
+        return $result !== false && count($result) !== count($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFlush()
+    {
+        return apcu_clear_cache();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetchMultiple(array $keys)
+    {
+        return apcu_fetch($keys) ?: [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSaveMultiple(array $keysAndValues, $lifetime = 0)
+    {
+        $result = apcu_store($keysAndValues, null, $lifetime);
+
+        return empty($result);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doGetStats()
+    {
+        $info = apcu_cache_info(true);
+        $sma  = apcu_sma_info();
+
+        return [
+            Cache::STATS_HITS             => $info['num_hits'],
+            Cache::STATS_MISSES           => $info['num_misses'],
+            Cache::STATS_UPTIME           => $info['start_time'],
+            Cache::STATS_MEMORY_USAGE     => $info['mem_size'],
+            Cache::STATS_MEMORY_AVAILABLE => $sma['avail_mem'],
+        ];
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Ray\RayDiForLaravel;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Ray\Compiler\AbstractInjectorContext;
+use Ray\Compiler\ContextInjector;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\InjectorInterface;
 use Ray\RayDiForLaravel\Attribute\Injectable;
@@ -20,10 +22,10 @@ class Application extends \Illuminate\Foundation\Application
     /** @var string[] */
     private array $abstractsResolvedByRay = [];
 
-    public function __construct(string $basePath, InjectorInterface $injector)
+    public function __construct(string $basePath, AbstractInjectorContext $injectorContext)
     {
         parent::__construct($basePath);
-        $this->injector = $injector;
+        $this->injector = ContextInjector::getInstance($injectorContext);
     }
 
     protected function resolve($abstract, $parameters = [], $raiseEvents = true)

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -21,7 +21,7 @@ class ApplicationTest extends TestCase
         $service = $app->make(InjectableService::class);
         $result = $service->run();
 
-        $this->assertEquals('Hello, Ray!', $result);
+        $this->assertEquals('Hello, Ray! Intercepted.', $result);
     }
 
     public function testResolvedByIlluminateWhenNonMarkedClassGiven(): void

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -5,18 +5,19 @@ declare(strict_types=1);
 namespace Ray\RayDiForLaravel;
 
 use PHPUnit\Framework\TestCase;
-use Ray\Di\Injector;
+use Ray\Compiler\AbstractInjectorContext;
+use Ray\RayDiForLaravel\Classes\FakeCacheableContext;
+use Ray\RayDiForLaravel\Classes\FakeContext;
 use Ray\RayDiForLaravel\Classes\GreetingServiceProvider;
 use Ray\RayDiForLaravel\Classes\IlluminateGreeting;
 use Ray\RayDiForLaravel\Classes\InjectableService;
-use Ray\RayDiForLaravel\Classes\Module;
 use Ray\RayDiForLaravel\Classes\NonInjectableService;
 
 class ApplicationTest extends TestCase
 {
     public function testResolvedByRayWhenMarkedClassGiven(): void
     {
-        $app = $this->createApplication();
+        $app = $this->createApplication(FakeContext::class);
 
         $service = $app->make(InjectableService::class);
         $result = $service->run();
@@ -26,7 +27,7 @@ class ApplicationTest extends TestCase
 
     public function testResolvedByIlluminateWhenNonMarkedClassGiven(): void
     {
-        $app = $this->createApplication();
+        $app = $this->createApplication(FakeContext::class);
 
         $service = $app->make(NonInjectableService::class);
         $result = $service->run();
@@ -36,18 +37,50 @@ class ApplicationTest extends TestCase
 
     public function testResolvedByIlluminateWhenNonClassStringGiven(): void
     {
-        $app = $this->createApplication();
+        $app = $this->createApplication(FakeContext::class);
 
         $greeting = $app->make('greeting');
 
         $this->assertInstanceOf(IlluminateGreeting::class, $greeting);
     }
 
-    private function createApplication(): Application
+    /**
+     * @requires extension apcu
+     */
+    public function testCacheableContext(): void
+    {
+        $app = $this->createApplication(FakeCacheableContext::class);
+
+        $service = $app->make(InjectableService::class);
+        $result = $service->run();
+
+        $this->assertEquals('Hello, Ray! Intercepted.', $result);
+    }
+
+    /**
+     * @depends testCacheableContext
+     */
+    public function testCache(): void
+    {
+        $baseDir = __DIR__ . '/tmp/Ray_RayDiForLaravel_Classes_FakeCacheableContext';
+        $this->assertDirectoryExists($baseDir);
+        $this->assertFileExists($baseDir . '/_aop.txt');
+        $this->assertFileExists($baseDir . '/_module.txt');
+        $this->assertFileExists($baseDir . '/Ray_RayDiForLaravel_Classes_FakeInterceptor-.php');
+        $this->assertFileExists($baseDir . '/Ray_RayDiForLaravel_Classes_FakeInterface-.php');
+        $this->assertFileExists($baseDir . '/Ray_RayDiForLaravel_Classes_FakeInterfaceNull.php');
+        $this->assertFileExists($baseDir . '/Ray_RayDiForLaravel_Classes_GreetingInterface-.php');
+        $this->assertFileExists($baseDir . '/Ray_RayDiForLaravel_Classes_InjectableService-.php');
+    }
+
+    /**
+     * @param class-string<AbstractInjectorContext> $contextClass
+     */
+    private function createApplication(string $contextClass): Application
     {
         $app = new Application(
             dirname(__DIR__),
-            new Injector(new Module())
+            new $contextClass(dirname(__DIR__) . '/tests')
         );
         $app->register(GreetingServiceProvider::class);
 

--- a/tests/Classes/Attribute/StringDecorator.php
+++ b/tests/Classes/Attribute/StringDecorator.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes\Attribute;
+
+use Attribute;
+
+#[Attribute]
+final class StringDecorator
+{
+}

--- a/tests/Classes/Fake.php
+++ b/tests/Classes/Fake.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes;
+
+class Fake implements FakeInterface
+{
+    public function __invoke()
+    {
+    }
+}

--- a/tests/Classes/FakeCacheableContext.php
+++ b/tests/Classes/FakeCacheableContext.php
@@ -40,8 +40,6 @@ class FakeCacheableContext extends AbstractInjectorContext
 
     public function getCache(): CacheProvider
     {
-        $namespace = str_replace('\\', '_', $this::class);
-
-        return ApcuCacheProvider::create($namespace);
+        return ApcuCacheProvider::create();
     }
 }

--- a/tests/Classes/FakeCacheableContext.php
+++ b/tests/Classes/FakeCacheableContext.php
@@ -18,7 +18,7 @@ class FakeCacheableContext extends AbstractInjectorContext
         parent::__construct($tmpDir . '/tmp/' . $dir);
     }
 
-    public function getModule(): AbstractModule
+    public function __invoke(): AbstractModule
     {
         $module = new Module();
         $module->install(new DiCompileModule(true));
@@ -26,6 +26,7 @@ class FakeCacheableContext extends AbstractInjectorContext
             protected function configure()
             {
                 $this->bind(FakeInterface::class)->toNull();
+                $this->bind(InjectableService::class);
             }
         });
 

--- a/tests/Classes/FakeCacheableContext.php
+++ b/tests/Classes/FakeCacheableContext.php
@@ -40,6 +40,6 @@ class FakeCacheableContext extends AbstractInjectorContext
 
     public function getCache(): CacheProvider
     {
-        return ApcuCacheProvider::create();
+        return new ApcuCacheProvider();
     }
 }

--- a/tests/Classes/FakeCacheableContext.php
+++ b/tests/Classes/FakeCacheableContext.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes;
+
+use Doctrine\Common\Cache\CacheProvider;
+use Ray\Compiler\AbstractInjectorContext;
+use Ray\Compiler\DiCompileModule;
+use Ray\Di\AbstractModule;
+use Ray\RayDiForLaravel\ApcuCacheProvider;
+
+class FakeCacheableContext extends AbstractInjectorContext
+{
+    public function __construct(string $tmpDir)
+    {
+        $dir = str_replace('\\', '_', self::class);
+        parent::__construct($tmpDir . '/tmp/' . $dir);
+    }
+
+    public function getModule(): AbstractModule
+    {
+        $module = new Module();
+        $module->install(new DiCompileModule(true));
+        $module->override(new class extends AbstractModule {
+            protected function configure()
+            {
+                $this->bind(FakeInterface::class)->toNull();
+            }
+        });
+
+        return $module;
+    }
+
+    public function getSavedSingleton(): array
+    {
+        return [GreetingInterface::class];
+    }
+
+    public function getCache(): CacheProvider
+    {
+        $namespace = str_replace('\\', '_', $this::class);
+
+        return ApcuCacheProvider::create($namespace);
+    }
+}

--- a/tests/Classes/FakeContext.php
+++ b/tests/Classes/FakeContext.php
@@ -17,7 +17,7 @@ class FakeContext extends AbstractInjectorContext
         parent::__construct($tmpDir . '/tmp/' . $dir);
     }
 
-    public function getModule(): AbstractModule
+    public function __invoke(): AbstractModule
     {
         return new Module();
     }

--- a/tests/Classes/FakeContext.php
+++ b/tests/Classes/FakeContext.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes;
+
+use Doctrine\Common\Cache\CacheProvider;
+use Ray\Compiler\AbstractInjectorContext;
+use Ray\Di\AbstractModule;
+use Ray\Di\NullCache;
+
+class FakeContext extends AbstractInjectorContext
+{
+    public function __construct(string $tmpDir)
+    {
+        $dir = str_replace('\\', '_', self::class);
+        parent::__construct($tmpDir . '/tmp/' . $dir);
+    }
+
+    public function getModule(): AbstractModule
+    {
+        return new Module();
+    }
+
+    public function getSavedSingleton(): array
+    {
+        return [];
+    }
+
+    public function getCache(): CacheProvider
+    {
+        return new NullCache();
+    }
+}

--- a/tests/Classes/FakeInterceptor.php
+++ b/tests/Classes/FakeInterceptor.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes;
+
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+
+class FakeInterceptor implements MethodInterceptor
+{
+    public function invoke(MethodInvocation $invocation)
+    {
+        $result = $invocation->proceed();
+
+        return $result . ' Intercepted.';
+    }
+}

--- a/tests/Classes/FakeInterface.php
+++ b/tests/Classes/FakeInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Ray\RayDiForLaravel\Classes;
+
+interface FakeInterface
+{
+    public function __invoke();
+}

--- a/tests/Classes/InjectableService.php
+++ b/tests/Classes/InjectableService.php
@@ -9,12 +9,14 @@ use Ray\RayDiForLaravel\Attribute\Injectable;
 #[Injectable]
 final class InjectableService
 {
-    public function __construct(private GreetingInterface $greeting)
+    public function __construct(private GreetingInterface $greeting, private FakeInterface $fake)
     {
     }
 
     public function run(): string
     {
+        ($this->fake)();
+
         return $this->greeting->greet();
     }
 }

--- a/tests/Classes/Module.php
+++ b/tests/Classes/Module.php
@@ -5,11 +5,18 @@ declare(strict_types=1);
 namespace Ray\RayDiForLaravel\Classes;
 
 use Ray\Di\AbstractModule;
+use Ray\Di\Scope;
+use Ray\RayDiForLaravel\Classes\Attribute\StringDecorator;
 
 final class Module extends AbstractModule
 {
     protected function configure(): void
     {
-        $this->bind(GreetingInterface::class)->to(RayGreeting::class);
+        $this->bind(GreetingInterface::class)->to(RayGreeting::class)->in(Scope::SINGLETON);
+        $this->bindInterceptor(
+            $this->matcher->any(),
+            $this->matcher->annotatedWith(StringDecorator::class),
+            [FakeInterceptor::class]
+        );
     }
 }

--- a/tests/Classes/Module.php
+++ b/tests/Classes/Module.php
@@ -13,6 +13,7 @@ final class Module extends AbstractModule
     protected function configure(): void
     {
         $this->bind(GreetingInterface::class)->to(RayGreeting::class)->in(Scope::SINGLETON);
+        $this->bind(FakeInterface::class)->to(Fake::class);
         $this->bindInterceptor(
             $this->matcher->any(),
             $this->matcher->annotatedWith(StringDecorator::class),

--- a/tests/Classes/RayGreeting.php
+++ b/tests/Classes/RayGreeting.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Ray\RayDiForLaravel\Classes;
 
-final class RayGreeting implements GreetingInterface
+use Ray\RayDiForLaravel\Classes\Attribute\StringDecorator;
+
+class RayGreeting implements GreetingInterface
 {
+    #[StringDecorator]
     public function greet(): string
     {
         return 'Hello, Ray!';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,3 +3,13 @@
 declare(strict_types=1);
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+deleteFiles(__DIR__ . '/tmp');
+
+function deleteFiles(string $path): void
+{
+    foreach (array_filter((array) glob($path . '/*')) as $file) {
+        is_dir($file) ? deleteFiles($file) : unlink($file);
+        @rmdir($file);
+    }
+}


### PR DESCRIPTION
# 概要

`CachedInjectorFactory` を使い、context に応じて利用する injector を変更できるようにします。

# 方法

## bootstrap

次のような bootstrap になります。

```diff
- $app = new Illuminate\Foundation\Application(
-     $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
- );
+ $app = new Ray\RayDiForLaravel\ApplicationFactory(
+     $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__),
+     new PrdContext($_ENV['APP_BASE_PATH'] ?? dirname(__DIR__))
+ );
```

