### PR TITLE
Enable module override when test.

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -88,6 +88,31 @@ apcu拡張が有効な場合インジェクターをキャッシュします。
 独自のコンテキストが必要になる場合もあります。
 組み込みコンテキストを参考にカスタムコンテキストを実装し、`RayDi/Context/ContextProvider`で利用するようにします。
 
+### モジュールのオーバーライド
+
+テスト実行時にはテストケースによって束縛を変更したい場合があります。
+
+以下のように、テストクラスで `Ray\RayDiForLaravel\Testing\OverrideModule` を利用し、`$this->overrideModule` を呼び出してください。
+
+```php
+use Tests\TestCase;
+
+final class HelloTest extends TestCase
+{
+    use Ray\RayDiForLaravel\Testing\OverrideModule;
+
+    public function testStatusOk(): void
+    {
+        $this->overrideModule(new OverrideModule());
+    
+        $res = $this->get('/hello');
+
+        $res->assertOk();
+        $res->assertSeeText('Hello 1 * 2 = 2.');
+    }
+}
+```
+
 ## パフォーマンス
 
 [DiCompileModule](https://github.com/ray-di/Ray.Compiler/blob/1.x/src/DiCompileModule.php)をインストールすることで、

--- a/README.ja.md
+++ b/README.ja.md
@@ -103,7 +103,7 @@ final class HelloTest extends TestCase
 
     public function testStatusOk(): void
     {
-        $this->overrideModule(new OverrideModule());
+        $this->overrideModule(new MyModule());
     
         $res = $this->get('/hello');
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -90,9 +90,8 @@ apcu拡張が有効な場合インジェクターをキャッシュします。
 
 ### モジュールのオーバーライド
 
-テスト実行時にはテストケースによって束縛を変更したい場合があります。
-
-以下のように、テストクラスで `Ray\RayDiForLaravel\Testing\OverrideModule` を利用し、`$this->overrideModule` を呼び出してください。
+テストケースによって束縛を変更したい場合があります。
+その場合は、`Ray\RayDiForLaravel\Testing\OverrideModule`を利用し、テストクラスで`$this->overrideModule` を呼び出してください。
 
 ```php
 use Tests\TestCase;

--- a/README.md
+++ b/README.md
@@ -85,6 +85,31 @@ In the `RayDi/Context/ProductionContext`, the injector is cached if the apcu ext
 You may need your own context.
 Implement a custom context with reference to the built-in context and use it in `RayDi/Context/ContextProvider`.
 
+### Overriding Modules
+
+When running tests, you may want to change the binding depending on the test case.
+
+Use `Ray\RayDiForLaravel\Testing\OverrideModule` in your test class and call `$this->overrideModule` as shown below.
+
+```php
+use Tests\TestCase;
+
+final class HelloTest extends TestCase
+{
+    use Ray\RayDiForLaravel\Testing\OverrideModule;
+
+    public function testStatusOk(): void
+    {
+        $this->overrideModule(new OverrideModule());
+    
+        $res = $this->get('/hello');
+
+        $res->assertOk();
+        $res->assertSeeText('Hello 1 * 2 = 2.');
+    }
+}
+```
+
 ## Performance
 
 By installin the [DiCompileModule](https://github.com/ray-di/Ray.Compiler/blob/1.x/src/DiCompileModule.php), An optimized injector is used and dependency errors are reported at compile time, not at runtime.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ final class HelloTest extends TestCase
 
     public function testStatusOk(): void
     {
-        $this->overrideModule(new OverrideModule());
+        $this->overrideModule(new MyModule());
     
         $res = $this->get('/hello');
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.0",
         "ray/di": "^2.15.1",
-        "ray/compiler": "^1.9.2",
+        "ray/compiler": "^1.10",
         "doctrine/cache": "^1.10 || ^2.2"
     },
     "require-dev": {

--- a/src/Application.php
+++ b/src/Application.php
@@ -27,7 +27,7 @@ class Application extends \Illuminate\Foundation\Application
 
     private AbstractModule|null $overrideModule = null;
 
-    /** @var array<class-string<AbstractModule>, InjectorInterface> */
+    /** @var array<string, InjectorInterface> */
     private array $overrideInjectorInstance = [];
 
     public function __construct(string $basePath, AbstractInjectorContext $injectorContext)
@@ -93,14 +93,14 @@ class Application extends \Illuminate\Foundation\Application
             return $this->injector;
         }
 
-        $overrideModuleClass = $this->overrideModule::class;
+        $moduleString = md5((string) $this->overrideModule);
 
-        if (isset($this->overrideInjectorInstance[$overrideModuleClass])) {
-            return $this->overrideInjectorInstance[$overrideModuleClass];
+        if (isset($this->overrideInjectorInstance[$moduleString])) {
+            return $this->overrideInjectorInstance[$moduleString];
         }
 
         $injector = ContextInjector::getOverrideInstance($this->context, $this->overrideModule);
-        $this->overrideInjectorInstance[$overrideModuleClass] = $injector;
+        $this->overrideInjectorInstance[$moduleString] = $injector;
 
         return $injector;
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -93,14 +93,15 @@ class Application extends \Illuminate\Foundation\Application
             return $this->injector;
         }
 
-        $moduleString = md5((string) $this->overrideModule);
+        $currentModuleString = md5((string) $this->overrideModule);
 
-        if (isset($this->overrideInjectorInstance[$moduleString])) {
-            return $this->overrideInjectorInstance[$moduleString];
+        if (isset($this->overrideInjectorInstance[$currentModuleString])) {
+            return $this->overrideInjectorInstance[$currentModuleString];
         }
 
         $injector = ContextInjector::getOverrideInstance($this->context, $this->overrideModule);
-        $this->overrideInjectorInstance[$moduleString] = $injector;
+        $newModuleString = md5((string) $this->overrideModule);
+        $this->overrideInjectorInstance[$newModuleString] = $injector;
 
         return $injector;
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -93,14 +93,14 @@ class Application extends \Illuminate\Foundation\Application
             return $this->injector;
         }
 
-        $currentModuleString = md5((string) $this->overrideModule);
+        $currentModuleString = spl_object_hash($this->overrideModule);
 
         if (isset($this->overrideInjectorInstance[$currentModuleString])) {
             return $this->overrideInjectorInstance[$currentModuleString];
         }
 
         $injector = ContextInjector::getOverrideInstance($this->context, $this->overrideModule);
-        $newModuleString = md5((string) $this->overrideModule);
+        $newModuleString = spl_object_hash($this->overrideModule);
         $this->overrideInjectorInstance[$newModuleString] = $injector;
 
         return $injector;

--- a/src/Application.php
+++ b/src/Application.php
@@ -75,6 +75,7 @@ class Application extends \Illuminate\Foundation\Application
         parent::flush();
 
         $this->overrideModule = null;
+        $this->abstractsResolvedByRay = [];
     }
 
     public function overrideModule(AbstractModule $module): void

--- a/src/Application.php
+++ b/src/Application.php
@@ -27,8 +27,7 @@ class Application extends \Illuminate\Foundation\Application
 
     private AbstractModule|null $overrideModule = null;
 
-    /** @var array<string, InjectorInterface> */
-    private array $overrideInjectorInstance = [];
+    private InjectorInterface|null $overrideInjectorInstance = null;
 
     public function __construct(string $basePath, AbstractInjectorContext $injectorContext)
     {
@@ -79,12 +78,13 @@ class Application extends \Illuminate\Foundation\Application
 
         $this->overrideModule = null;
         $this->abstractsResolvedByRay = [];
-        $this->overrideInjectorInstance = [];
+        $this->overrideInjectorInstance = null;
     }
 
     public function overrideModule(AbstractModule $module): void
     {
         $this->overrideModule = $module;
+        $this->overrideInjectorInstance = null;
     }
 
     private function getInjector(): InjectorInterface
@@ -93,15 +93,12 @@ class Application extends \Illuminate\Foundation\Application
             return $this->injector;
         }
 
-        $currentModuleString = spl_object_hash($this->overrideModule);
-
-        if (isset($this->overrideInjectorInstance[$currentModuleString])) {
-            return $this->overrideInjectorInstance[$currentModuleString];
+        if ($this->overrideInjectorInstance !== null) {
+            return $this->overrideInjectorInstance;
         }
 
         $injector = ContextInjector::getOverrideInstance($this->context, $this->overrideModule);
-        $newModuleString = spl_object_hash($this->overrideModule);
-        $this->overrideInjectorInstance[$newModuleString] = $injector;
+        $this->overrideInjectorInstance = $injector;
 
         return $injector;
     }

--- a/src/Testing/OverrideModule.php
+++ b/src/Testing/OverrideModule.php
@@ -12,11 +12,11 @@ trait OverrideModule
     protected function overrideModule(AbstractModule $module): void
     {
         if (! property_exists($this, 'app')) {
-            return;
+            return; // @codeCoverageIgnore
         }
 
         if (! $this->app instanceof Application) {
-            return;
+            return; // @codeCoverageIgnore
         }
 
         $this->app->overrideModule($module);

--- a/src/Testing/OverrideModule.php
+++ b/src/Testing/OverrideModule.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Testing;
+
+use Ray\Di\AbstractModule;
+use Ray\RayDiForLaravel\Application;
+
+trait OverrideModule
+{
+    protected function overrideModule(AbstractModule $module): void
+    {
+        if (! property_exists($this, 'app')) {
+            return;
+        }
+
+        if (! $this->app instanceof Application) {
+            return;
+        }
+
+        $this->app->overrideModule($module);
+    }
+}

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -7,16 +7,14 @@ namespace Ray\RayDiForLaravel;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use PHPUnit\Framework\TestCase;
 use Ray\Compiler\AbstractInjectorContext;
-use Ray\Di\AbstractModule;
 use Ray\RayDiForLaravel\Classes\FakeCacheableContext;
 use Ray\RayDiForLaravel\Classes\FakeContext;
 use Ray\RayDiForLaravel\Classes\FakeInvalidContext;
-use Ray\RayDiForLaravel\Classes\GreetingInterface;
 use Ray\RayDiForLaravel\Classes\GreetingServiceProvider;
 use Ray\RayDiForLaravel\Classes\IlluminateGreeting;
 use Ray\RayDiForLaravel\Classes\InjectableService;
 use Ray\RayDiForLaravel\Classes\NonInjectableService;
-use Ray\RayDiForLaravel\Classes\OverrideGreeting;
+use Ray\RayDiForLaravel\Classes\OverrideGreetingModule;
 
 class ApplicationTest extends TestCase
 {
@@ -97,12 +95,7 @@ class ApplicationTest extends TestCase
     /** @depends testResolvedByRayWhenMarkedClassGiven  */
     public function testOverrideModule(Application $application): Application
     {
-        $overrideModule = new class extends AbstractModule {
-          protected function configure()
-          {
-              $this->bind(GreetingInterface::class)->to(OverrideGreeting::class);
-          }
-        };
+        $overrideModule = new OverrideGreetingModule();
         $application->overrideModule($overrideModule);
 
         $instance = $application->make(InjectableService::class);

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -17,6 +17,7 @@ use Ray\RayDiForLaravel\Classes\GreetingServiceProvider;
 use Ray\RayDiForLaravel\Classes\IlluminateGreeting;
 use Ray\RayDiForLaravel\Classes\InjectableService;
 use Ray\RayDiForLaravel\Classes\NonInjectableService;
+use Ray\RayDiForLaravel\Classes\OtherModule;
 use Ray\RayDiForLaravel\Classes\OverrideGreetingModule;
 
 class ApplicationTest extends TestCase
@@ -116,6 +117,17 @@ class ApplicationTest extends TestCase
 
         $this->assertInstanceOf(InjectableService::class, $instance);
         $this->assertSame('Hello, override!', $instance->run());
+    }
+
+    /** @depends testOverrideModule */
+    public function testSameModuleAndHasParentModule(Application $application): void
+    {
+        $application->overrideModule(new OverrideGreetingModule(new OtherModule()));
+
+        $instance = $application->make(InjectableService::class);
+
+        $this->assertInstanceOf(InjectableService::class, $instance);
+        $this->assertSame('Hello, override!Fake', $instance->run());
     }
 
     /** @depends testOverrideModule */

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -7,9 +7,12 @@ namespace Ray\RayDiForLaravel;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use PHPUnit\Framework\TestCase;
 use Ray\Compiler\AbstractInjectorContext;
+use Ray\Di\AbstractModule;
 use Ray\RayDiForLaravel\Classes\FakeCacheableContext;
 use Ray\RayDiForLaravel\Classes\FakeContext;
+use Ray\RayDiForLaravel\Classes\FakeGreeting;
 use Ray\RayDiForLaravel\Classes\FakeInvalidContext;
+use Ray\RayDiForLaravel\Classes\GreetingInterface;
 use Ray\RayDiForLaravel\Classes\GreetingServiceProvider;
 use Ray\RayDiForLaravel\Classes\IlluminateGreeting;
 use Ray\RayDiForLaravel\Classes\InjectableService;
@@ -104,6 +107,34 @@ class ApplicationTest extends TestCase
         $this->assertSame('Hello, override!', $instance->run());
 
         return $application;
+    }
+
+    /** @depends testOverrideModule */
+    public function testAlreadyResolvedOverrideModule(Application $application): void
+    {
+        $instance = $application->make(InjectableService::class);
+
+        $this->assertInstanceOf(InjectableService::class, $instance);
+        $this->assertSame('Hello, override!', $instance->run());
+    }
+
+    /** @depends testOverrideModule */
+    public function testSetOtherOverrideModule(Application $application): void
+    {
+        $overrideModule = new class extends AbstractModule {
+
+            protected function configure()
+            {
+                $this->bind(GreetingInterface::class)->to(FakeGreeting::class);
+            }
+        };
+
+        $application->overrideModule($overrideModule);
+
+        $instance = $application->make(InjectableService::class);
+
+        $this->assertInstanceOf(InjectableService::class, $instance);
+        $this->assertSame('Hello, fake!', $instance->run());
     }
 
     /** @depends testOverrideModule */

--- a/tests/Classes/FakeFoo.php
+++ b/tests/Classes/FakeFoo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes;
+
+class FakeFoo implements FooInterface
+{
+    public function __invoke(): string
+    {
+        return 'Fake';
+    }
+}

--- a/tests/Classes/FakeGreeting.php
+++ b/tests/Classes/FakeGreeting.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes;
+
+class FakeGreeting implements GreetingInterface
+{
+    public function greet(): string
+    {
+        return 'Hello, fake!';
+    }
+}

--- a/tests/Classes/Foo.php
+++ b/tests/Classes/Foo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes;
+
+class Foo implements FooInterface
+{
+    public function __invoke(): string
+    {
+        return '';
+    }
+}

--- a/tests/Classes/FooInterface.php
+++ b/tests/Classes/FooInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Ray\RayDiForLaravel\Classes;
+
+interface FooInterface
+{
+    public function __invoke(): string;
+}

--- a/tests/Classes/InjectableService.php
+++ b/tests/Classes/InjectableService.php
@@ -9,14 +9,15 @@ use Ray\RayDiForLaravel\Attribute\Injectable;
 #[Injectable]
 final class InjectableService
 {
-    public function __construct(private GreetingInterface $greeting, private FakeInterface $fake)
+    public function __construct(private GreetingInterface $greeting, private FakeInterface $fake, private FooInterface $foo)
     {
     }
 
     public function run(): string
     {
         ($this->fake)();
+        $value = ($this->foo)();
 
-        return $this->greeting->greet();
+        return $this->greeting->greet() . $value;
     }
 }

--- a/tests/Classes/Module.php
+++ b/tests/Classes/Module.php
@@ -14,6 +14,7 @@ final class Module extends AbstractModule
     {
         $this->bind(GreetingInterface::class)->to(RayGreeting::class)->in(Scope::SINGLETON);
         $this->bind(FakeInterface::class)->to(Fake::class);
+        $this->bind(FooInterface::class)->to(Foo::class);
         $this->bindInterceptor(
             $this->matcher->any(),
             $this->matcher->annotatedWith(StringDecorator::class),

--- a/tests/Classes/OtherModule.php
+++ b/tests/Classes/OtherModule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes;
+
+use Ray\Di\AbstractModule;
+
+class OtherModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(FooInterface::class)->to(FakeFoo::class);
+    }
+}

--- a/tests/Classes/OverrideGreeting.php
+++ b/tests/Classes/OverrideGreeting.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes;
+
+class OverrideGreeting implements GreetingInterface
+{
+    public function greet(): string
+    {
+        return 'Hello, override!';
+    }
+}

--- a/tests/Classes/OverrideGreetingModule.php
+++ b/tests/Classes/OverrideGreetingModule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel\Classes;
+
+use Ray\Di\AbstractModule;
+
+class OverrideGreetingModule extends AbstractModule
+{
+
+    protected function configure()
+    {
+        $this->bind(GreetingInterface::class)->to(OverrideGreeting::class);
+    }
+}

--- a/tests/OverrideModuleTest.php
+++ b/tests/OverrideModuleTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\RayDiForLaravel;
+
+use PHPUnit\Framework\TestCase;
+use Ray\RayDiForLaravel\Classes\FakeContext;
+use Ray\RayDiForLaravel\Classes\GreetingServiceProvider;
+use Ray\RayDiForLaravel\Classes\InjectableService;
+use Ray\RayDiForLaravel\Classes\OverrideGreetingModule;
+use Ray\RayDiForLaravel\Testing\OverrideModule;
+
+class OverrideModuleTest extends TestCase
+{
+    use OverrideModule;
+
+    private \Illuminate\Foundation\Application $app;
+
+    protected function setUp(): void
+    {
+        $this->app = new Application(
+            dirname(__DIR__),
+            new FakeContext(dirname(__DIR__) . '/tests')
+        );
+
+        $this->app->register(GreetingServiceProvider::class);
+    }
+
+    public function testAppIsRayDiApplication(): void
+    {
+        $this->overrideModule(new OverrideGreetingModule());
+
+        $instance = $this->app->make(InjectableService::class);
+        $actual = $instance->run();
+
+        $this->assertSame('Hello, override!', $actual);
+    }
+}


### PR DESCRIPTION
テスト実行時にモジュールをオーバライド可能にしました。

* overrideModule が指定されている場合は、Injectorを生成
* テストでは `OverrideModule` トレイトを使います。`$this->app` の型が親クラスに定義されており、上書きできないためこの方法にしています。 


demoアプリに適用した際の差分は以下のとおりです。
https://github.com/koriym/hello-ray-di-for-laravel/compare/master...NaokiTsuchiya:feat/override-module?expand=1