### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         php: [8.0, 8.1, 8.2, 8.3, 8.4]
-        laravel: [8, 9, 10, 11]
+        laravel: [8.83, 9, 10, 11]
         dependency: [lowest, highest]
         os: [ubuntu-latest]
         exclude:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,15 +52,15 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
+      - name: Set Laravel
+        run: composer require --dev laravel/framework:^${{ matrix.laravel }} --no-interaction --no-update
+
       - name: Handle lowest dependencies update
         if: contains(matrix.dependency, 'lowest')
         run: echo COMPOSER_UPDATE_FLAGS=$COMPOSER_UPDATE_FLAGS --prefer-lowest >> $GITHUB_ENV
 
       - name: Update dependencies
         run: composer update ${{ env.COMPOSER_UPDATE_FLAGS }} ${{ env.COMPOSER_FLAGS }}
-
-      - name: Update laravel
-        run: composer update ${{ env.COMPOSER_UPDATE_FLAGS }} ${{ env.COMPOSER_FLAGS }} -W laravel/framework:^${{ matrix.laravel }}
 
       - name: Run test suite
         run: ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "laravel/framework": "^8.83 || ^9.8 || ^10.0 || ^11.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5.10"
     },
     "suggest": {
       "ext-apcu": "Needed to use ApcuCacheProvider"


### PR DESCRIPTION
[The latest Actions](https://github.com/ray-di/Ray.RayDiForLaravel/actions/runs/11643046343) has failed. 

In this PR, the following were implemented and fixed.

* Set Laravel version before updating dependencies
* Fix Laravel 8 version in CI
* Fix minimum version of phpunit/phpunit to avoid error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Laravel version specification in the CI workflow to ensure compatibility with newer features.
	- Introduced a new step to manage Laravel dependencies more effectively during continuous integration.
	- Updated PHPUnit dependency version in the development environment for improved testing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->