### PR TITLE
Support Laravel v12

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,16 +18,25 @@ jobs:
     strategy:
       matrix:
         php: [8.0, 8.1, 8.2, 8.3, 8.4]
-        laravel: [8.83, 9, 10, 11]
+        laravel: [8.83, 9, 10, 11, 12]
         dependency: [lowest, highest]
         os: [ubuntu-latest]
         exclude:
+          # Laravel 10+ requires PHP 8.1+
           - php: 8.0
             laravel: 10
+          # Laravel 11+ requires PHP 8.2+
           - php: 8.0
             laravel: 11
           - php: 8.1
             laravel: 11
+          # Laravel 12+ requires PHP 8.3+
+          - php: 8.0
+            laravel: 12
+          - php: 8.1
+            laravel: 12
+          - php: 8.2
+            laravel: 12
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,6 +22,14 @@ jobs:
         dependency: [lowest, highest]
         os: [ubuntu-latest]
         exclude:
+          # Laravel 8.x (8.83) doesn't support PHP 8.3+
+          - php: 8.3
+            laravel: 8.83
+          - php: 8.4
+            laravel: 8.83
+          # Laravel 9.x doesn't support PHP 8.4
+          - php: 8.4
+            laravel: 9
           # Laravel 10+ requires PHP 8.1+
           - php: 8.0
             laravel: 10

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "doctrine/cache": "^1.10 || ^2.2"
     },
     "require-dev": {
-        "laravel/framework": "^8.83 || ^9.8 || ^10.0 || ^11.0",
+        "laravel/framework": "^8.83 || ^9.8 || ^10.0 || ^11.0 || ^12.0",
         "phpunit/phpunit": "^9.5.10"
     },
     "suggest": {


### PR DESCRIPTION
## Summary by Sourcery

Add support for Laravel v12 by updating Composer dev dependencies and expanding the CI matrix with appropriate PHP version constraints.

New Features:
- Support Laravel framework v12

Enhancements:
- Allow Laravel/framework ^12.0 in composer.json require-dev

CI:
- Include Laravel 12 in the GitHub Actions CI matrix
- Adjust PHP version exclusions to enforce Laravel 10+ on PHP 8.1+, Laravel 11+ on PHP 8.2+, and Laravel 12+ on PHP 8.3+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to support Laravel 12.
  * Enhanced continuous integration to test against Laravel 12, ensuring compatibility with required PHP versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->